### PR TITLE
Add sfgov.org to domain list

### DIFF
--- a/lib/domains.yml
+++ b/lib/domains.yml
@@ -182,3 +182,4 @@
 - mil.uy
 - mil.vc
 - mil.ve
+- sfgov.org


### PR DESCRIPTION
@jasonlally the domain is restricted to government employees, correct?
