### PR TITLE
Added Ottawa.ca

### DIFF
--- a/lib/domains.txt
+++ b/lib/domains.txt
@@ -136,6 +136,7 @@ gov.ve
 gov.vn
 gov.ws
 gub.uy
+ottawa.ca
 
 //non-US mil
 mil.ac


### PR DESCRIPTION
Ottawa.ca domain emails are only given out to City of Ottawa employees
