### PR TITLE
Added some canadian cites, top level provinces and second level province...

### DIFF
--- a/lib/domains.txt
+++ b/lib/domains.txt
@@ -137,6 +137,34 @@ gov.vn
 gov.ws
 gub.uy
 
+//canadian-cities
+ottawa.ca
+toronto.ca
+ajax.ca
+hamilton.ca
+guelph.ca
+vancouver.ca
+london.ca
+niagarafalls.ca
+
+//canadian provinces top-level domains
+alberta.ca
+ontario.ca
+novascotia.ca
+gnb.ca
+newfoundlandlabrador.com
+
+//canadian provinces second-level domains
+pe.ca
+mb.ca
+nb.ca
+on.ca
+bc.ca
+qc.ca
+sk.ca
+nl.ca
+ns.ca
+
 //non-US mil
 mil.ac
 mil.ae


### PR DESCRIPTION
... domains

Note that not all second level domains work out directly.  Example: qc.ca is the domain owned by the Province of Quebec but you must use: gouv.qc.ca to get to the actual website.  This is similar to how gc.ca domains work.
