### PR TITLE
add si.edu domain

### DIFF
--- a/lib/domains.txt
+++ b/lib/domains.txt
@@ -2,6 +2,7 @@
 fed.us
 gov
 mil
+si.edu
 
 // Non-US gov
 gc.ca


### PR DESCRIPTION
This adds `si.edu`, the Smithsonian to the :+1: domains.
