### PR TITLE
Add Pierce County, Washington

### DIFF
--- a/lib/domains.txt
+++ b/lib/domains.txt
@@ -193,6 +193,7 @@ mil.ve
 bouldercounty.org
 ci.champaign.il.us
 ci.longmont.co.us
+co.pierce.wa.us
 sfgov.org
 sfmta.org
 sfcta.org


### PR DESCRIPTION
This request adds the co.pierce.wa.us domain which is owned by Pierce County, WA to the whitelist of accepted domains.
