### PR TITLE
Fixes syntax error, bad variable name, and lets test file run on its own

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,10 +12,18 @@ require 'rake'
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/test_*.rb'
+  test.pattern = 'test/**/test_gman*.rb'
   test.verbose = true
 end
 
+desc "Open console with gman loaded"
 task :console do
   exec "irb -r ./lib/gman.rb"
+end
+
+desc "Run extra tests that hit the Internet"
+Rake::TestTask.new(:remote) do |test|
+  test.libs << 'lib' << 'test'
+  test.pattern = 'test/**/test_remote*.rb'
+  test.verbose = true
 end

--- a/test/test_gman.rb
+++ b/test/test_gman.rb
@@ -27,12 +27,6 @@ INVALID = [ "foo.bar.com",
 
 class TestGman < Test::Unit::TestCase
 
-  def domain_resolves?(domain)
-    res = Net::DNS::Resolver.new
-    res.nameservers = ["8.8.8.8","8.8.4.4", "208.67.222.222", "208.67.220.220"]
-    packet = res.search(domain, Net::DNS::NS)
-    packet.header.anCount > 0
-  end
 
   should "recognize government email addresses and domains" do
     VALID.each do |test|
@@ -94,13 +88,6 @@ class TestGman < Test::Unit::TestCase
       assert_equal true, Gman.valid?("foo.#{entry.name}"), "foo.#{entry.name} is not a valid domain"
     end
   end
-
-  should "only contain resolvable domains" do
-    Gman.list.each do |entry|
-      assert_equal true, domain_resolves?(entry.name), entry.name
-    end
-  end
-
 
   should "not err out on invalid domains" do
     assert_equal false, Gman.valid?("foo@act.gov.au")

--- a/test/test_remote.rb
+++ b/test/test_remote.rb
@@ -1,0 +1,18 @@
+require File.join(File.dirname(__FILE__), 'helper')
+
+class TestRemote < Test::Unit::TestCase
+
+  def domain_resolves?(domain)
+    res = Net::DNS::Resolver.new
+    res.nameservers = ["8.8.8.8","8.8.4.4", "208.67.222.222", "208.67.220.220"]
+    packet = res.search(domain, Net::DNS::NS)
+    packet.header.anCount > 0
+  end
+
+  should "only contain resolvable domains" do
+    Gman.list.each do |entry|
+      assert_equal true, domain_resolves?(entry.name), "Could not resolve #{entry.name}"
+    end
+  end
+
+end


### PR DESCRIPTION
However, this reveals that one of the tests, of resolvable domains, is failing. I added output that shows that it fails first on `gob.bo`.

Also, having the test suite make 9,000 remote calls during its run is maybe poor form, and Travis-hostile. That might be better placed in a separate test file that is run when a human wants to check, not during the main test suite that executes upon a plain `rake`.
