### PR TITLE
drop email veracity

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     gman (1.0.0)
       addressable
-      email_veracity
       public_suffix
       swot
 
@@ -18,7 +17,6 @@ GEM
       tzinfo (~> 0.3.37)
     addressable (2.3.5)
     atomic (1.1.14)
-    email_veracity (0.6.0)
     i18n (0.6.9)
     json (1.8.1)
     minitest (4.7.5)

--- a/README.md
+++ b/README.md
@@ -29,14 +29,6 @@ Gman.valid? "foo@bar.gov" #true
 Gman.valid? "foo@bar.com" #false
 ```
 
-### Really verify an email address
-
-(also verifies that the server returns a valid MX record)
-
-```ruby
-Gman.valid? "foo@whitehouse.gov", true #true
-Gman.valid? "foo@bar.gov", true #false
-```
 ### Verify domain
 
 ```ruby
@@ -53,8 +45,6 @@ Gman.get_domain "http://foo.bar.gov" # foo.bar.gov
 Gman.get_domain "foo@bar.gov" # bar.gov
 Gman.get_domain "foo.bar.gov" # foo.bar.gov
 Gman.get_domain "asdf@asdf" # nil (no domain within the string)
-Gman.get_domain "foo@bar.gov", true #false (no MX record)
-Gman.get_domain "foo@whitehouse.gov", true # true (valid MX record)
 ```
 
 ## Contributing

--- a/gman.gemspec
+++ b/gman.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency( "public_suffix" )
   s.add_dependency( "swot" )
-  s.add_dependency( "email_veracity" )
   s.add_dependency( "addressable" )
 
   s.add_development_dependency( "rake" )

--- a/test/test_gman.rb
+++ b/test/test_gman.rb
@@ -53,12 +53,6 @@ class TestGman < Test::Unit::TestCase
     assert_equal nil, Gman.get_domain("foo")
   end
 
-  should "validate mx records when asked" do
-    assert_equal true, Gman.valid?("foo@nasa.gov", true)
-    assert_equal false, Gman.valid?("foo@github.gov", true)
-    assert_equal true, Gman.valid?("foo@github.gov", false)
-  end
-
   should "not err out on invalid domains" do
     assert_equal false, Gman.valid?("foo@act.gov.au")
     assert_equal "act.gov.au", Gman.get_domain("foo@act.gov.au")


### PR DESCRIPTION
Email veracity [is dead](https://github.com/heycarsten/email-veracity#deprecation-notice). Long live email veracity.
