### PR TITLE
add government of BC, Canada main domain

### DIFF
--- a/lib/domains.txt
+++ b/lib/domains.txt
@@ -342,6 +342,7 @@ govt.nz
 gub.uy
 ottawa.ca
 gov.yk.ca
+gov.bc.ca
 
 // non-us mil
 mil.ac


### PR DESCRIPTION
Please add gov.bc.ca to this file. gov.bc.ca is the main domain used by the British Columbia government of Canada.
