### PR TITLE
Add Bulgaria's government main domain

### DIFF
--- a/lib/domains.txt
+++ b/lib/domains.txt
@@ -338,6 +338,7 @@ gov.ve
 gov.vn
 gov.ws
 gov.za
+government.bg
 govt.nz
 gub.uy
 ottawa.ca


### PR DESCRIPTION
The website is on [www.government.bg](http://www.government.bg/) (does not work without the `www` subdomain). The emails are at `@government.bg`.
