### PR TITLE
Public suffix exception support

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -1452,6 +1452,7 @@ ontario.ca
 saskatchewan.ca
 
 // non-us gov
+!mail.gov.ua
 admin.ch
 dep.no
 gob.bo

--- a/lib/gman.rb
+++ b/lib/gman.rb
@@ -44,9 +44,10 @@ class Gman < NaughtyOrNice
 
     # check using public suffix's standard logic
     rule = Gman.list.find domain
-    return true if !rule.nil? && rule.allow?(domain)
 
-    # also allow for explicit matches to domain list
-    Gman.list.rules.any? { |rule| rule.value == domain }
+    # domain is on the domain list and
+    # domain is not explicitly blacklisted and
+    # domain matches a standard public suffix list rule
+    !rule.nil? && rule.type != :exception && rule.allow?(".#{domain}")
   end
 end

--- a/test/test_gman.rb
+++ b/test/test_gman.rb
@@ -29,7 +29,8 @@ INVALID = [ "foo.bar.com",
             " ",
             "foo.city.il.us",
             "foo.ci.il.us",
-            "foo.zx.us"
+            "foo.zx.us",
+            "foo@mail.gov.ua"
           ]
 
 class TestGman < Minitest::Test


### PR DESCRIPTION
This pull request adds support for `!domain.gov` style public suffix exceptions and simplifies the domain checkling logic to rely more heavily on PublicSuffix's internal mechanisms.

`mail.gov.ua` is publically registerable.

/cc https://github.com/weppos/publicsuffix-ruby/issues/63

