### PR TITLE
Add support for Japanese domains

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -1883,6 +1883,7 @@ xanten.de
 !mail.gov.ua
 admin.ch
 dep.no
+go.jp
 gob.bo
 gob.cl
 gob.do

--- a/config/domains.txt
+++ b/config/domains.txt
@@ -2018,6 +2018,7 @@ gov.za
 government.bg
 govt.nz
 gub.uy
+lg.jp
 nic.in
 
 // non-us mil


### PR DESCRIPTION
@dice realized Gman didn't know Japanese domains. Do these two look right to you (meaning any website or email ending in `go.jp` or `lg.jp` should belong to a government agency / employee). (via [from wikipedia](https://en.wikipedia.org/wiki/.jp#Second-level_domains).

