### PR TITLE
Add the swiss canton Grisons domain.

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -2087,6 +2087,7 @@ bs.ch
 fr.ch
 ge.ch
 gl.ch
+gr.ch
 ju.ch
 lu.ch
 ne.ch


### PR DESCRIPTION
The domain was missing from the existing list.