### PR TITLE
Rescue from ISO resolution errors

### DIFF
--- a/lib/gman/country_codes.rb
+++ b/lib/gman/country_codes.rb
@@ -37,5 +37,7 @@ class Gman < NaughtyOrNice
   # Gman.new("foo.gov").country.currency => "USD"
   def country
     @country ||= IsoCountryCodes.find(alpha2) if alpha2
+  rescue IsoCountryCodes::UnknownCodeError
+    nil
   end
 end

--- a/test/test_gman_country_codes.rb
+++ b/test/test_gman_country_codes.rb
@@ -7,4 +7,8 @@ class TestGmanCountryCodes < Minitest::Test
     assert_equal "United Kingdom of Great Britain and Northern Ireland", Gman.new("foo.gov.uk").country.name
     assert_equal "Canada", Gman.new("foo.gc.ca").country.name
   end
+
+  should "not err out on an unknown country code" do
+    assert_equal nil, Gman.new("foo.eu").country
+  end
 end


### PR DESCRIPTION
e.g. `IsoCountryCodes::UnknownCodeError: No ISO 3166-1 code could be found for 'EU'.`