### PR TITLE
Add lus.org and lusfiber.com under usgovLA

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -5409,6 +5409,8 @@ lsbwdd.org
 lsli.org
 lsp.org
 lsuagcenter.com
+lus.org
+lusfiber.com
 mindenusa.com
 muttshack.org
 mybossier.com


### PR DESCRIPTION
lus.org is a government corporation wholly owned by Lafayette City-Parish
Consolidated Government (lafayettela.gov).

lusfiber.com is a wholly owned subsidy of lus.org (.net is the non-employee
customer addresses).

All users of lus.org and lusfiber.com (not .net) addresses are Civil Servants
under LCPCG.