### PR TITLE
Remove colorize

### DIFF
--- a/bin/gman
+++ b/bin/gman
@@ -1,7 +1,6 @@
 #! /usr/bin/env ruby
 # Given a domain-link string, returns information about the domain
 
-require 'colorize'
 require_relative "../lib/gman"
 
 # Convenience method to simplify the command-line logic
@@ -14,10 +13,9 @@ class IsoCountryCodes
 end
 
 domain = ARGV[0]
-String.disable_colorization = true if ARGV.last == "--no-color"
 
-if domain.to_s.empty? || domain == "--no-color"
-  puts "USAGE: gman <domain or email address> [--no-color]".red
+if domain.to_s.empty?
+  puts "USAGE: gman <domain or email address>"
   exit 1
 end
 
@@ -26,20 +24,20 @@ gman = Gman.new(domain)
 puts "Domain  : #{gman.domain}"
 
 if gman.domain.nil?
-  puts "Status  : " + "Invalid domain".red
+  puts "Status  : " + "Invalid domain"
   exit 1
 end
 
 if !gman.valid?
-  puts "Status  : " + "Not a government domain".red
+  puts "Status  : " + "Not a government domain"
   exit 1
 end
 
-puts "Status  : " + "Valid government domain".green
+puts "Status  : " + "Valid government domain"
 
 ["type", "country", "state", "city", "agency"].each do |key|
   value = gman.send(key)
   puts "#{key.capitalize.ljust(8)}: #{value}" if value
 end
 
-puts "SANCTIONED NATION".red if gman.sanctioned?
+puts "SANCTIONED NATION" if gman.sanctioned?

--- a/gman.gemspec
+++ b/gman.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency( "swot", '~> 1.0' )
   s.add_dependency( "iso_country_codes", "~> 0.6" )
   s.add_dependency( "naughty_or_nice", "~> 2.0" )
-  s.add_dependency( "colorize", "~> 0.7" )
 
   s.add_development_dependency( "rake" )
   s.add_development_dependency( "shoulda" )

--- a/test/test_gman_bin.rb
+++ b/test/test_gman_bin.rb
@@ -54,13 +54,9 @@ class TestGmanBin < Minitest::Test
     assert_equal 0, @status.exitstatus
   end
 
-  should "allow you to disable colorization" do
+  should "ignores old colorization option" do
     output, status = test_bin("whitehouse.gov", "--no-color")
     refute_match /\[0;32;49m/, output
-  end
-
-  should "color by default" do
-    assert_match /\[0;32;49m/, @output
   end
 
   should "show help text" do
@@ -68,9 +64,6 @@ class TestGmanBin < Minitest::Test
     assert_match /Usage/i, output
 
     output, status = test_bin("")
-    assert_match /Usage/i, output
-
-    output, status = test_bin("--no-color")
     assert_match /Usage/i, output
   end
 


### PR DESCRIPTION
[colorize](https://rubygems.org/gems/colorize) is GPL. It's only loaded if `bin/gman` is invoked, but the declared dependency in the gemspec theoretically means all of gman should be GPL.