### PR TITLE
adds Madrid to Spain municipal

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -3131,6 +3131,9 @@ met.no
 mil.no
 nav.no
 
+// Spain Municipal
+madrid.es
+
 // Swedish Administrative Authorities
 aklagare.se
 arbetsformedlingen.se


### PR DESCRIPTION
Adds `madrid.es`, the Spanish Madrid government domain