### PR TITLE
Add Maricopa County Library District (mcldaz.org)

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -3709,6 +3709,7 @@ guadalupeaz.org
 litchfield-park.org
 marana.com
 maricopacfc.org
+mcldaz.org
 mohavecounty.us
 pvaz.net
 queencreek.org


### PR DESCRIPTION
Add the Maricopa County Library District (mcldaz.org) to the list of government domains.