### PR TITLE
City of Nanterre domain

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -3066,6 +3066,7 @@ govt.nz
 gub.uy
 leg.br
 lg.jp
+mairie-nanterre.fr
 mil.tr
 nic.in
 onroerenderfgoed.be


### PR DESCRIPTION
adding the City of Nanterre, France domain to the whitelist