### PR TITLE
Add New York MTA domains

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -9076,8 +9076,15 @@ mbpo.org
 mechanicville.com
 middlefieldny.com
 middletown-ny.com
+mnr.org
 monroeny.org
 mountkisco.org
+mtabsc.org
+mtabt.org
+mtabusco.com
+mtacc.info
+mtahq.org
+mtapd.org
 mtpleasantny.com
 munseypark.org
 newcastle-ny.org
@@ -9103,6 +9110,7 @@ norwoodny.org
 nyack.org
 nyccfc.org
 nycom.org
+nyct.com
 nyhistory.org
 nysca.org
 nysdmv.com


### PR DESCRIPTION
This adds the following domains used for email by the New York [Metropolitan Transportation Authority](http://www.mta.info), a state agency:

```
mtabusco.com
nyct.com
mtacc.info
mnr.org
mtabsc.org
mtabt.org
mtahq.org
mtapd.org
```