### PR TITLE
Add Vegvesen (Norweigen Public Roads Authority) to domain list

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -3135,6 +3135,7 @@ kartverket.no
 met.no
 mil.no
 nav.no
+vegvesen.no
 
 // Spain Municipal
 madrid.es


### PR DESCRIPTION
http://www.vegvesen.no/en/

> The Norwegian Public Roads Administration strives to ensure that all those who walk, cycle, travel by car or use public transport should get to their destination safely. We plan, build, operate and maintain national and county roads in Norway. We are also responsible for carrying out driver tests and inspection of vehicles and road users.

Submitted on behalf of Kaare Knudsen
