### PR TITLE
Miami Parking Authority

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -4728,6 +4728,7 @@ marioncountyfl.org
 melbournebeachfl.org
 melbourneflorida.org
 miamigov.com
+miamiparking.com
 miamishoresvillage.com
 midwayfl.com
 mycarrabelle.com


### PR DESCRIPTION
http://miamiparking.com/
City of Miami's division of on and off street parking.