### PR TITLE
Supporting US Military domains

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -6697,6 +6697,14 @@ wmsrdc.org
 woodhavenmi.org
 wyandotte.net
 
+// usagovMIL
+mail.mil
+navy.mil
+usmc.mil
+marines.mil
+nrl.navy.mil
+erdc.dren.mil
+
 // usagovMN
 albanytownship.com
 alexandriatownship.org


### PR DESCRIPTION
We don't support the common (us) military email domains (even though we do have non-us ones). Starting to rectify this.