### PR TITLE
Update domains.txt

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -3357,6 +3357,9 @@ vs.ch
 zg.ch
 zh.ch
 
+// UK
+historicengland.org.uk
+
 // US Combined Federal Campaigns
 3riverscfc.org
 cbacfc.org


### PR DESCRIPTION
Request to add [historicengland.org.uk](https://www.historicengland.org.uk) to the accepted domain list.
Historic England *is an executive non-departmental public body, sponsored by the [Department for Culture, Media & Sport](https://www.gov.uk/government/organisations/department-for-culture-media-sport).*