### PR TITLE
Add Health Education England addition to Domains

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -11564,6 +11564,7 @@ zh.ch
 
 // UK
 historicengland.org.uk
+hee.nhs.uk
 
 // US Combined Federal Campaigns
 3riverscfc.org


### PR DESCRIPTION
Request to add HEE (Health Education England) to list of supported domains.

https://www.hee.nhs.uk/
https://www.gov.uk/government/organisations/health-education-england

>Health Education England (HEE) is the new national leadership organisation for education, training and workforce development in the health sector. HEE is an executive non-departmental public body, sponsored by the Department of Health.