### PR TITLE
Add austinenergy.com to approved domain list

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -19246,6 +19246,7 @@ annetta.org
 anra.org
 argyletx.com
 austincounty.com
+austinenergy.com
 banderacounty.org
 baylorcountytexas.us
 baytown.org


### PR DESCRIPTION
Austin Energy is a utility company for the City of Austin, which is a government entity (austintexas.gov).