### PR TITLE
Add vta.org to approved domain list

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -12456,6 +12456,7 @@ ventura.org
 vesd.net
 villapark.org
 visitcalifornia.com
+vta.org
 walnut-creek.org
 walnutcreeksd.org
 weho.org


### PR DESCRIPTION
Please add our government agency - SCVTA (Santa Clara Valley Transit Authority)

https://github.com/vta/

Per email from Jamie Jones (GitHub Government Team) <government@github.com>