### PR TITLE
Add governo.it to domains.txt

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -10569,9 +10569,10 @@ wuerselen.de
 wuppertal.de
 xanten.de
 
-// Italian municipalities
+// Italian government and municipalities
 comune.bologna.it
 formez.it
+governo.it
 plonegov.it
 regione.emilia-romagna.it
 


### PR DESCRIPTION
This is the main domain name for central government websites.