### PR TITLE
Add @codefor and @amsterdam for netherlands

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -10658,7 +10658,6 @@ ccmo.nl
 ceg.nl
 cibg.nl
 coevorden.nl
-codefor.nl
 cpb.nl
 cranendonck.nl
 cromstrijen.nl

--- a/config/domains.txt
+++ b/config/domains.txt
@@ -10607,6 +10607,7 @@ alphenaandenrijn.nl
 ameland.nl
 amersfoort.nl
 amstelveen.nl
+amsterdam.nl
 apeldoorn.nl
 appingedam.nl
 arnhem.nl
@@ -10657,6 +10658,7 @@ ccmo.nl
 ceg.nl
 cibg.nl
 coevorden.nl
+codefor.nl
 cpb.nl
 cranendonck.nl
 cromstrijen.nl


### PR DESCRIPTION
heyyyyyyy @benbalter et al, I got a request from a local Dutchy to add these two domains. 

`@amsterdam` seems normal, but i wasn't sure if we add organizations like `codefor.nl`? From the http://www.codefor.nl/ website it says (translated from googles):

> The Dutch Code for NL Foundation is the Dutch network of open source developers and designers who work together on the digital government.
>
> Our goal is the successful digital transformation of municipalities, other governments and society as a whole.
>
>Code for NL is governing partner of the international Code for All network.

[Seems Legit](http://i.imgur.com/xisRvmp.gif) to me!