### PR TITLE
Add `amsterdam.nl` to domain whitelist

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -10607,6 +10607,7 @@ alphenaandenrijn.nl
 ameland.nl
 amersfoort.nl
 amstelveen.nl
+amsterdam.nl
 apeldoorn.nl
 appingedam.nl
 arnhem.nl


### PR DESCRIPTION
For the City of Amsterdam.

Closes #152 