### PR TITLE
domains.txt - Adds main Czech ministry domains

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -1429,6 +1429,11 @@ saskatchewan.ca
 // Catalonia
 gencat.cat
 
+// Czech republic government
+justice.cz
+mvcr.cz
+mfcr.cz
+
 // Denmark
 skat.dk
 


### PR DESCRIPTION
Adds Ministry of Justice Czech Republic (justice.cz), Ministry of Interior Czech Republic (mvcr.cz) and Ministry of Finance Czech Republic (mfcr.cz)