### PR TITLE
Exclude education.nsw.gov.au (NSW school emails)

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -11278,6 +11278,7 @@ lg.jp
 mil.tr
 nic.in
 onroerenderfgoed.be
+!education.nsw.gov.au
 !mail.gov.ua
 
 // non-us mil


### PR DESCRIPTION
NSW public school students receive an email address at
education.nsw.gov.au.  These students should probably not be considered
as employeed by a government.

This has the unfortunate side effect of marking the website itself as
not a government website...