### PR TITLE
Add South Australian state goverment domain

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -11278,6 +11278,7 @@ lg.jp
 mil.tr
 nic.in
 onroerenderfgoed.be
+sa.gov.au
 !education.nsw.gov.au
 !mail.gov.ua
 


### PR DESCRIPTION
Refer to https://www.sa.gov.au/
