### PR TITLE
Add korea.kr for South Korea

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -10710,6 +10710,9 @@ governo.it
 plonegov.it
 regione.emilia-romagna.it
 
+// Korea, South
+korea.kr
+
 // Lithuania
 vpt.lt
 


### PR DESCRIPTION
There is no source in English but there's a [newspaper][1] saying "korea.kr" is "central email address" for Korean government.

Less reliable source (blog of government employee) cites the service as "[national government entity and local government entity's central mail service][2]".

[1]: http://biz.chosun.com/site/data/html_dir/2015/07/24/2015072402332.html
[2]: https://www.seojoohyun.com/2018/10/korea-kr.html

Examples:
- [National Library of Korea](https://www.nl.go.kr/app/nl/organization/organ_pop2.jsp?groupCd=100) (www.nl.go.kr) [Wikipedia](https://w.wiki/6ob) says "go.kr" for their employee phonebooks.
- [Chilgok County](http://www.chilgok.go.kr/program/search/04.jsp?collection=col_emp&query=정)(chilgok.go.kr - [Chilgok County](https://w.wiki/6oc)) - they have korea.kr as an email. ([screenshot](https://tppr.me/xYKeP))
- [NEWS: Government Employees in Jeju Province now use korea.kr email](http://www.jejusori.net/news/articleView.html?idxno=110094) - "제주도는 2005년부터 도입한 제주넷 웹메일시스템(@jeju.go.kr)을 2월말까지 운영하고, 3월부터는 정부에서 운영하는 통합메일시스템(@korea.kr)으로 전환한다고 29일 밝혔다." -> "Jeju Province has announced that JejuNet web mail system introduced in 2005 would be shut down by end of February, and migrate to Government-operated central mail system (@korea.kr) after March."