### PR TITLE
docs: Link directly to domains.txt

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Feature requests are welcome. But take a moment to find out whether your idea fi
 
 ## Domains
 
-Domains live in `./config/domains.txt` as a list of TLDs and SLD+TLDs.
+Domains live in [`config/domains.txt`](../config/domains.txt) as a list of TLDs and SLD+TLDs.
 
 Right now, the only valid government top level domains (TLDs), represent the US government and are `.gov`, and `.mil`. Secondary domains (e.g., `gov.uk`, or `mil.au`) represent non-US government entities.
 


### PR DESCRIPTION
Was looking for the file, and saves a step of navigating the tree

-----
[View rendered docs/CONTRIBUTING.md](https://github.com/nschonni/gman/blob/patch-1/docs/CONTRIBUTING.md)