### PR TITLE
Add Metropolitan Area Planning Council

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -14412,6 +14412,7 @@ lincolntown.org
 littletonma.org
 longmeadow.org
 mansfieldma.com
+mapc.org
 marblehead.org
 massbudget.org
 massculturalcouncil.org


### PR DESCRIPTION
The Metropolitan Area Planning Council is the regional planning agency serving the 101 municipalities in the Boston metro region. MAPC employees are state employees of the Commonwealth of Massachusetts.