### PR TITLE
Add existing Los Angeles domains

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -12827,6 +12827,14 @@ la-quinta.org
 lacanadaflintridge.com
 lacity.gov
 lacity.org
+lawa.org
+portofla.org
+ladwp.com
+lapd.online
+lapl.org
+lacers.org
+lafpp.com
+hacla.org
 lacounty.gov
 lagunabeachcity.net
 lagunawoodscity.org


### PR DESCRIPTION
The government domains list has a few missing:

Add:

lawa.org
portofla.org - this domain is used for email instead of portoflosangeles.org. it's located in the portoflosangeles.org footer.
ladwp.com
lapd.online - this domain is used for email instead of lapdonline.org. the domain can be hard to find if you don't know where to look (https://www.lapdonline.org/information-on-how-to-file-a-complaint/).
lapl.org
lacers.org
lafpp.com
hacla.org

This PR addresses it 👍

Note: These are the eight City of Los Angeles departments that don't use lacity.org or lacity.gov for email.