### PR TITLE
Add NYC Municipal Domains

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -17538,6 +17538,8 @@ northsyracuse.org
 northtonawanda.org
 norwichnewyork.net
 nyack.org
+nyc.gov
+nyc.ny.us
 nycom.org
 nyct.com
 nyhistory.org


### PR DESCRIPTION
Add 'nyc.gov' and 'nyc.ny.us' as acceptable municipal domains.