### PR TITLE
Addition of domains from Spain

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -11596,10 +11596,14 @@ tptc.org.sg
 
 // Spain Municipal
 madrid.es
+zaragoza.es
 
 // Spain Provincial
 itracasa.es
 navarra.es
+
+// Spain Autonomic
+aragon.es
 
 // Swedish Administrative Authorities
 aklagare.se


### PR DESCRIPTION
Addition of the domain of the autonomous community of Aragón (Spain) and the city of Zaragoza (Spain).