### PR TITLE
Add Slovak Federal domains

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -11248,6 +11248,7 @@ gov.sd
 gov.se
 gov.sg
 gov.sl
+gov.sk
 gov.st
 gov.sy
 gov.tm
@@ -11342,6 +11343,24 @@ prpg-tc.org.sg
 sbtc.org.sg
 tampines.org.sg
 tptc.org.sg
+
+// Slovak Federal
+justice.sk
+mfsr.sk
+mhsr.sk
+mincrs.sk
+mindop.sk
+minedu.sk
+minv.sk
+minzp.sk
+mksr.sk
+mpsr.sk
+mpsvr.sk
+mzsr.sk
+mzv.sk
+
+// Slovak Municipalities
+// TBD
 
 // Spain Municipal
 madrid.es

--- a/config/domains.txt
+++ b/config/domains.txt
@@ -11306,6 +11306,7 @@ mil.pl
 mil.py
 mil.qa
 mil.ru
+mil.sk
 mil.tm
 mil.tw
 mil.tz
@@ -11346,6 +11347,7 @@ tptc.org.sg
 
 // Slovak Federal
 justice.sk
+slovensko.sk
 mfsr.sk
 mhsr.sk
 mincrs.sk


### PR DESCRIPTION
Please, accept addition of the Slovak Federal domains.

[Ministry of Investment, Regional Development and Informatics of the Slovak Republic](https://mirri.gov.sk/en/) is the [Administrative contact for .sk TLD domain](https://www.iana.org/domains/root/db/sk.html).
The [NASES Agency is subordinate and contributory organization to our Ministry](https://nases.gov.sk/en/o-nas/cinnost-agentury) and responsible for administration of [gov.sk domain](https://whois.sk-nic.sk/) and operation of [Central Government Portal](https://www.slovensko.sk/en/about-us).

The [Ministry of Defence](https://www.mosr.sk/) is the Owner of [.mil.sk domain](https://whois.sk-nic.sk/).

[Other Ministries](https://sk.wikipedia.org/wiki/Zoznam_ministerstiev_na_Slovensku#Aktu%C3%A1lne_ministerstv%C3%A1) are owners of their respective public domains listed.