### PR TITLE
Adding state of Colorado USA email domain

### DIFF
--- a/config/domains.txt
+++ b/config/domains.txt
@@ -12776,6 +12776,7 @@ rtd-denver.com
 sanmiguelcounty.org
 silverthorne.org
 springsgov.com
+state.co.us
 steamboatsprings.net
 sterlingcolo.com
 strattoncolorado.com


### PR DESCRIPTION
I found this repository from https://github.com/government/welcome?tab=readme-ov-file

It seems the state email domain is not in the list, so I added it.